### PR TITLE
stop tab buttons from scrolling around

### DIFF
--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -683,7 +683,7 @@ class TabbedPanel(GridLayout):
         tab_pos = self.tab_pos
         tab_layout = self._tab_layout
         tab_layout.clear_widgets()
-        scrl_v = ScrollView(size_hint=(None, 1))
+        scrl_v = ScrollView(size_hint=(None, 1), always_overscroll=False)
         tabs = self._tab_strip
         parent = tabs.parent
         if parent:


### PR DESCRIPTION
The always_overscroll (default true) option that was added to ScrollView in #6678 causes the buttons of TabbedPanel to always scroll